### PR TITLE
resourcetype in xml response for non collections

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -2486,6 +2486,7 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
                 stringresp += "<lp1:resourcetype><D:collection/></lp1:resourcetype>\n";
                 stringresp += "<lp1:iscollection>1</lp1:iscollection>\n";
               } else {
+                stringresp += "<lp1:resourcetype/>\n";
                 stringresp += "<lp1:iscollection>0</lp1:iscollection>\n";
               }
 
@@ -2602,6 +2603,7 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
                   stringresp += "<lp1:resourcetype><D:collection/></lp1:resourcetype>\n";
                   stringresp += "<lp1:iscollection>1</lp1:iscollection>\n";
                 } else {
+                  stringresp += "<lp1:resourcetype/>\n";
                   stringresp += "<lp1:iscollection>0</lp1:iscollection>\n";
                 }
 


### PR DESCRIPTION
Currently, the XRootD PROPFIND response doesn't include 'resourcetype' in the response for non-collections. 

Some webdav clients expect that tag to be there for all responses, not just if it's a collection. As such, I've adjusted the return so it adds the tag in the response for non collections.