### PR TITLE
Fix XRootD local build error caused by `libXrdAccSciTokens`

### DIFF
--- a/src/XrdSciTokens/CMakeLists.txt
+++ b/src/XrdSciTokens/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library(${XrdAccSciTokens} MODULE
 target_link_libraries(${XrdAccSciTokens}
   PRIVATE
     XrdSciTokensObj
+    ${SCITOKENS_CPP_LIBRARIES}
 )
 
 install(


### PR DESCRIPTION
When I try to build-install-run XRootD on my local Linux-Alam container, I got the following error right after starting the XRootD server:

```
undefined symbol: enforcer_create authlib libXrdAccSciTokens-5.so
```

XRootD SciTokens plugin wasn't properly linked against the SciTokens library during the build. The problem is in the CMakeLists.txt for the SciTokens plugin. The library (libXrdAccSciTokens-5.so) is built from object files, but it's not explicitly linked against the SciTokens library.

In this PR, I modified CMakeLists.txt to properly link this plugin